### PR TITLE
Pretrain improvements

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -67,7 +67,7 @@ def graph_performance(time):
     sns.lineplot(data=eval_log, x='epoch', y='loss', hue='eval')
     plt.xlabel('Training Epoch')
     plt.ylabel('Model Performance')
-    plt.ylim([0, 2])
+    plt.ylim([0, 2.5])
     plt.grid()
     plt.savefig(path + f'/epoch_performance_{time}.png', dpi=200)
     plt.close()

--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,82 @@
+import pandas as pd
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+import json
+
+# accuracy
+# top n accuracy
+# loss by epoch
+
+def compute_accuracy(time, top_n=2):
+    '''
+    Compute top 1 and top n accuracy, with grand totals.
+    '''
+
+    # load data
+    data = pd.read_csv(path+ f'/predictions_{time}.csv')
+    proba_cols = data.columns[2:]
+
+    # add custom match_n for top_n accuracy calc
+    match = []
+    for i in range(len(data)):
+        top = data[proba_cols].iloc[i].nlargest(top_n).index.tolist()
+        match.append(data['actual'].iloc[i] in top)
+    data['match_n'] = match
+    data['match'] = data['actual'] == data['predicted_label']
+
+    # prep for grand total rollup
+    data['grand_total'] = 'grand total'
+
+    # compute metrics by totals
+    g_all = data.groupby(by='grand_total').agg({'match_n': 'mean', 'match': ['mean', 'count']}).reset_index()
+    g_all = g_all.rename(columns={'grand_total': 'actual'})
+
+    # compute metrics by label
+    g = data.groupby(by='actual').agg({'match_n': 'mean', 'match': ['mean', 'count']}).reset_index()
+
+    # combine and rename columns
+    g = pd.concat([g, g_all], axis=0).reset_index(drop=True)
+    g.columns = ['anime', f'top-{top_n} accuracy %', 'top-1 accuracy %', 'num_images']
+    
+    print(g)
+    g.to_csv(path+f'/accuracy_{time}.csv', index=False)
+
+
+def graph_performance(time):
+    '''
+    Load model log and plot epoch-by-epoch performance.
+    '''
+    
+    with open(path + f'/model_json_{time}.json', 'r') as f:
+        model_json = json.load(f)
+
+    data = []
+    for log in model_json:
+        if 'loss' in log:
+            data.append([log['epoch'], 'train_loss', log['loss']])
+        elif 'eval_loss' in log and 'eval_accuracy' in log:
+            data.append([log['epoch'], 'eval_loss', log['eval_loss']])
+            data.append([log['epoch'], 'eval_accuracy', log['eval_accuracy']])
+        elif 'eval_loss' in log:
+            data.append([log['epoch'], 'eval_loss', log['eval_loss']])
+        else:
+            pass
+    
+    eval_log = pd.DataFrame(columns=['epoch', 'eval', 'loss'], data=data)
+
+    plt.figure()
+    sns.lineplot(data=eval_log, x='epoch', y='loss', hue='eval')
+    plt.xlabel('Training Epoch')
+    plt.ylabel('Model Performance')
+    plt.ylim([0, 2])
+    plt.grid()
+    plt.savefig(path + f'/epoch_performance_{time}.png', dpi=200)
+    plt.close()
+
+
+path = '/Users/jonah.krop/Documents/USC/usc_dsci_565_project/training_results'
+time = '1732207905'
+
+graph_performance(time)
+compute_accuracy(time)

--- a/analysis.py
+++ b/analysis.py
@@ -3,10 +3,8 @@ import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
 import json
+import os
 
-# accuracy
-# top n accuracy
-# loss by epoch
 
 def compute_accuracy(time, top_n=2):
     '''
@@ -39,7 +37,7 @@ def compute_accuracy(time, top_n=2):
     g = pd.concat([g, g_all], axis=0).reset_index(drop=True)
     g.columns = ['anime', f'top-{top_n} accuracy %', 'top-1 accuracy %', 'num_images']
     
-    print(g)
+    # print(g)
     g.to_csv(path+f'/accuracy_{time}.csv', index=False)
 
 
@@ -76,7 +74,8 @@ def graph_performance(time):
 
 
 path = '/Users/jonah.krop/Documents/USC/usc_dsci_565_project/training_results'
-time = '1732207905'
+times = sorted([f.split('.')[0][-10:] for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f[0:11] == 'predictions'])
 
-graph_performance(time)
-compute_accuracy(time)
+for time in times:
+    graph_performance(time)
+    compute_accuracy(time)

--- a/repeat_train.sh
+++ b/repeat_train.sh
@@ -1,5 +1,10 @@
 #!/bin/zsh
 
-#python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0 --batch_size=16 --pretrained
-python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0 --batch_size=16
+#python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0 --batch_size=16 --epochs=3
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0 --batch_size=32 --epochs=5
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.1 --batch_size=32 --epochs=5
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.2 --batch_size=32 --epochs=5
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0 --batch_size=32 --epochs=5 --add_noise
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.1 --batch_size=32 --epochs=5 --add_noise
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.2 --batch_size=32 --epochs=5 --add_noise
 

--- a/repeat_train.sh
+++ b/repeat_train.sh
@@ -1,6 +1,5 @@
 #!/bin/zsh
 
-#python3 transfer_learning.py --model='google/efficientnet-b3' --pretrained=False --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0
-#python3 transfer_learning.py --model='google/efficientnet-b3' --pretrained=False --train_test_split=0.25 --learning_rate=1e-2 --weight_decay=0
+#python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0 --batch_size=16 --pretrained
 python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0 --batch_size=16
 

--- a/repeat_train.sh
+++ b/repeat_train.sh
@@ -1,0 +1,6 @@
+#!/bin/zsh
+
+#python3 transfer_learning.py --model='google/efficientnet-b3' --pretrained=False --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0
+#python3 transfer_learning.py --model='google/efficientnet-b3' --pretrained=False --train_test_split=0.25 --learning_rate=1e-2 --weight_decay=0
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0 --batch_size=16
+

--- a/repeat_train.sh
+++ b/repeat_train.sh
@@ -1,10 +1,10 @@
 #!/bin/zsh
 
 #python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0 --batch_size=16 --epochs=3
-python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0 --batch_size=32 --epochs=5
-python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.1 --batch_size=32 --epochs=5
-python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.2 --batch_size=32 --epochs=5
-python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0 --batch_size=32 --epochs=5 --add_noise
-python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.1 --batch_size=32 --epochs=5 --add_noise
-python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-4 --weight_decay=0.2 --batch_size=32 --epochs=5 --add_noise
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0.1 --batch_size=32 --epochs=6
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0.2 --batch_size=32 --epochs=6
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0.3 --batch_size=32 --epochs=6
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0.1 --batch_size=32 --epochs=6 --add_noise
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0.2 --batch_size=32 --epochs=6 --add_noise
+python3 transfer_learning.py --model='google/efficientnet-b3' --train_test_split=0.25 --learning_rate=1e-3 --weight_decay=0.3 --batch_size=32 --epochs=6 --add_noise
 

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -214,6 +214,7 @@ if __name__ == '__main__':
     train_results = model.train_model(train, test).state.log_history
     train_params = {
         'model': args.model,
+        'pretrained': args.pretrained,
         'learning_rate': args.learning_rate,
         'batch_size': args.batch_size,
         'epochs': args.epochs,

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -17,7 +17,7 @@ class dataset():
     '''
     def __init__(self, noise=False, directory='', train_test_split=0):
         self.noise = noise
-        self.data_path = directory + '/data/tensors.pt' if not noise else '/data/tensors_noise.pt'
+        self.data_path = directory + '/data/tensors.pt' if not noise else directory + '/data/tensors_noise.pt'
         self.label_path = directory + '/data/anime_label_map.json'
         self.train_test_split=train_test_split
 

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -88,7 +88,7 @@ class classifier():
 
         # reset weights if we're not using a pretrained model
         if not self.pretrained:
-            model.init_weights()
+            self.classifier.init_weights()
 
         # define initial hyperparameters for training the model
         args_d = {


### PR DESCRIPTION
Turns out it's not enough to call `model.init_weights` to reset the pre-trained model weights (not totally clear why, it might be only resetting the weights on the final fully connected layer but i'm not really sure). Instead, required doing a weird initialization of the model using `AutoConfig` rather than directly initializing the model with `.from_pretrained()`. 

execution now works by defaulting to _not_ using pre-trained weights, unless the `--pretrained` argument is provided. for example, can run

`python transfer_learning.py --pretrained --model='google/efficientnet-b3' --epochs=2.0 --batch_size=16`


also added a couple things
 - quick `analysis.py` script that spits out a couple things for each trained model:
   - a train/eval loss graph by epoch from the generated `model_json_{epoch_runtime}.json`
   - an aggregate accuracy measurement by label
 - `repeat_train.sh` bash script that executes the `transfer_learning.py` script because I got tired of typing out all the arguments every time, and makes it easy to run the script multiple times in a row with different parameters