### PR TITLE
Fix labels (temp fix)

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
     print('all in-sample downloads finished')
 
     label_map = dict(enumerate(animes))
-    label_map[11] = 'noise'
+    label_map[10] = 'noise'
     with open('./data/anime_label_map.json', 'w') as f:
         json.dump(label_map, f)
 

--- a/repeat_train.ps1
+++ b/repeat_train.ps1
@@ -1,0 +1,20 @@
+# pretrained w/ noise
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.3
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.2
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.1
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.01
+# pretrained w/o noise
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.3
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.2
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.1
+python transfer_learning.py --model microsoft/resnet-18 --directory . --pretrained --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.01
+# random w/ noise
+python transfer_learning.py --model microsoft/resnet-18 --directory . --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.3
+python transfer_learning.py --model microsoft/resnet-18 --directory . --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.2
+python transfer_learning.py --model microsoft/resnet-18 --directory . --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.1
+python transfer_learning.py --model microsoft/resnet-18 --directory . --add_noise --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.01
+# random w/o noise
+python transfer_learning.py --model microsoft/resnet-18 --directory . --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.3
+python transfer_learning.py --model microsoft/resnet-18 --directory . --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.2
+python transfer_learning.py --model microsoft/resnet-18 --directory . --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.1
+python transfer_learning.py --model microsoft/resnet-18 --directory . --epochs 4.0 --batch_size 32 --learning_rate 1e-3 --weight_decay 0.01

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -30,7 +30,9 @@ class dataset():
         
         # load all data
         tensors = torch.load(self.data_path)
-        all_data = Dataset.from_dict({'pixel_values': [t[0] for t in tensors], 'labels': [t[1] for t in tensors]})
+        all_data = Dataset.from_dict(
+            {'pixel_values': [t[0] for t in tensors],
+             'labels': [t[1] if t[1] < 10 else 10 for t in tensors]})
         
         # optionally apply a train/test split
         if self.train_test_split > 0:

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -49,7 +49,7 @@ class dataset():
             labels = json.load(f)
 
         if not self.noise:
-            del labels['11']
+            del labels['10']
 
         return labels
 


### PR DESCRIPTION
There is a gap in labels from 9 -> 11. I forgot to index at 0. This should give us a temp solution without having to run the preprocessing script again. Just remember to manually change the label in `anime_label_map.json` for noise from 11 to 10.