### PR TITLE
adding some functionality to the analysis script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /training_results
 .DS_Store
 __pycache__
+repeat_train.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 __pycache__
 repeat_train.sh
+repeat_train.ps1

--- a/analysis.py
+++ b/analysis.py
@@ -105,6 +105,11 @@ def make_heatmap(time):
 
 
 def summarize(time):
+    '''
+    Summarize a set of predictions in one line, with accuracy by category
+    and training parameters for quick reference.
+    '''
+
     # load data
     data = pd.read_csv(path+f'/predictions_{time}.csv')
     data['match'] = data['actual'] == data['predicted_label']
@@ -117,12 +122,7 @@ def summarize(time):
     with open(path+f'/model_json_{time}.json', 'r') as f:
         log = json.load(f)
 
-
-    ['haikyuu', 'jujutsukaisen', 'chainsawman', 'sousounofrieren', 'spyxfamily',
-                'bluelock', 'skiptoloafer', 'kimetsunoyaibayuukakuhen',
-                'deaddeaddemonsdededededestruction', 'durarara']
-
-
+    # build row
     summ = [
         time,
         params['model'],
@@ -159,7 +159,7 @@ args = parser.parse_args()
 path = args.resultdir
 times = sorted([f.split('.')[0][-10:] for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f[0:11] == 'predictions'])
 
-
+# go thru every prediction file and do stuff
 combined = []
 for time in times:
     graph_performance(time)
@@ -167,6 +167,7 @@ for time in times:
     make_heatmap(time)
     combined.append(summarize(time))
 
+# make the combined, summarized dataset
 combined_cols = [
     'run_timestamp',
     'model',
@@ -190,6 +191,5 @@ combined_cols = [
     'noise_accuracy',
     'runtime_mins'
 ]
-
 df = pd.DataFrame(data=combined, columns=combined_cols)
 df.to_csv(path+'/combined_results.csv', index=False)

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -118,9 +118,9 @@ class classifier():
             'eval_steps': 100,
             'logging_steps': 100,
             'per_device_eval_batch_size': self.per_device_train_batch_size,
-            'seed': 0,
-            'save_total_limit': 5,
-            'load_best_model_at_end': True
+            'seed': 0
+            # 'save_total_limit': 5,
+            # 'load_best_model_at_end': True
         }
         m_args = TrainingArguments(**args_d)
 

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -118,7 +118,9 @@ class classifier():
             'eval_steps': 100,
             'logging_steps': 100,
             'per_device_eval_batch_size': self.per_device_train_batch_size,
-            'seed': 0
+            'seed': 0,
+            'save_total_limit': 5,
+            'load_best_model_at_end': True
         }
         m_args = TrainingArguments(**args_d)
 


### PR DESCRIPTION
Adding a couple functions to the analysis script
 - `summarize()`, which summarizes a set of predictions by returning a row of data containing the model params and the accuracy obtained. at the end of the script, concatenates all the rows from each set of predictions and creates one `combined_results.csv` that more easily summarizes model performance with respect to training arguments and parameters
 - `make_heatmap()`, which creates a graph of actual vs. predicted categories and the % of predictions that fall in each bucket

also added a small tweak to the `transfer_learning.py` script to force it to load and save the best-performing model at the end of training rather than the state at the final step, and added the `repeat_train.sh` file to gitignore so we don't overwrite each other's training pipelines